### PR TITLE
use empty instead of ! check

### DIFF
--- a/src/I18nBundle/EventListener/I18nStartupListener.php
+++ b/src/I18nBundle/EventListener/I18nStartupListener.php
@@ -85,7 +85,7 @@ class I18nStartupListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$document->getProperty('language')) {
+        if (empty($document->getProperty('language'))) {
             $this->buildEditModeResponse($event);
         }
     }


### PR DESCRIPTION
the empty() is more readable than the ! in case of an empty-string-or-null check